### PR TITLE
Handle sidekiq config error_handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - gemfiles/rails7_1.gemfile
           - gemfiles/rails7_2.gemfile
           - gemfiles/rails8_0.gemfile
+          - gemfiles/pinned_dependencies.gemfile
           - Gemfile
     steps:
       - name: Checkout repository

--- a/gemfiles/pinned_dependencies.gemfile
+++ b/gemfiles/pinned_dependencies.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0.0"
+
+# Include any dependencies here that need to be specifically tested.
+gem "sidekiq", "7.1.0" # >= 7.1.5 for the conditional in sidekiq.rb to check parameter cardinality
+
+gemspec path: "../"

--- a/lib/exception_notification/sidekiq.rb
+++ b/lib/exception_notification/sidekiq.rb
@@ -3,7 +3,12 @@
 require "sidekiq"
 
 ::Sidekiq.configure_server do |config|
-  config.error_handlers << proc do |ex, context|
-    ExceptionNotifier.notify_exception(ex, data: {sidekiq: context})
+  config.error_handlers << proc do |ex, context, config|
+    # Before Sidekiq 7.1.5 the config was not passed to the proc
+    if config
+      ExceptionNotifier.notify_exception(ex, data: {sidekiq: {context: context, config: config}})
+    else
+      ExceptionNotifier.notify_exception(ex, data: {sidekiq: context})
+    end
   end
 end

--- a/test/exception_notifier/sidekiq_test.rb
+++ b/test/exception_notifier/sidekiq_test.rb
@@ -24,10 +24,17 @@ class SidekiqTest < ActiveSupport::TestCase
     message = {}
     exception = RuntimeError.new
 
-    ExceptionNotifier.expects(:notify_exception).with(
-      exception,
-      data: {sidekiq: message}
-    )
+    if ::Sidekiq::VERSION < "7.1.5"
+      ExceptionNotifier.expects(:notify_exception).with(
+        exception,
+        data: {sidekiq: message}
+      )
+    else
+      ExceptionNotifier.expects(:notify_exception).with(
+        exception,
+        data: {sidekiq: {context: message, config: server.config}}
+      )
+    end
 
     server.handle_exception(exception, message)
   end


### PR DESCRIPTION
This copies over the changes from https://github.com/smartinez87/exception_notification/pull/537 and adds a test.

I don't like putting version detection in a test. I guess I could skip the tests depending on version and run different examples. I could also make the assertion less specific and run the same test with `anything` matcher.