### PR TITLE
Match gemspec files explicitly

### DIFF
--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -14,8 +14,14 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.2"
 
-  s.files = `git ls-files | grep -v '^examples'`.split("\n")
-  s.files -= `git ls-files -- .??*`.split("\n")
+  s.files = Dir[
+    "lib/**/*",
+    "docs/**/*",
+    "MIT-LICENSE",
+    "Rakefile",
+    "*.md",
+    "*.rdoc"
+  ].reject { |f| File.directory?(f) }
   s.require_path = "lib"
 
   s.add_dependency("actionmailer", ">= 7.1", "< 9")

--- a/exception_notification.gemspec
+++ b/exception_notification.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
     "lib/**/*",
     "docs/**/*",
     "MIT-LICENSE",
+    "exception_notification.gemspec",
     "Rakefile",
     "*.md",
     "*.rdoc"


### PR DESCRIPTION
Solves #8 (regression from a4ef785d91d972a77b5ac7ba6624100bf3c2a854).

This includes the files we want to package explicity, removing the files below from the package.
<details>
  <summary>diff of included files</summary>

  ```console
  $ diff old-files-sorted new-files-sorted
  ```

  ```diff
  16,22d15
  < exception_notification.gemspec
  < Gemfile
  < Gemfile.lock
  < gemfiles/pinned_dependencies.gemfile
  < gemfiles/rails7_1.gemfile
  < gemfiles/rails7_2.gemfile
  < gemfiles/rails8_0.gemfile
  68,90d60
  < test/exception_notification/rack_test.rb
  < test/exception_notification/rake_test.rb
  < test/exception_notification/resque_test.rb
  < test/exception_notifier/datadog_notifier_test.rb
  < test/exception_notifier/email_notifier_test.rb
  < test/exception_notifier/google_chat_notifier_test.rb
  < test/exception_notifier/hipchat_notifier_test.rb
  < test/exception_notifier/irc_notifier_test.rb
  < test/exception_notifier/mattermost_notifier_test.rb
  < test/exception_notifier/modules/error_grouping_test.rb
  < test/exception_notifier/modules/formatter_test.rb
  < test/exception_notifier/sidekiq_test.rb
  < test/exception_notifier/slack_notifier_test.rb
  < test/exception_notifier/sns_notifier_test.rb
  < test/exception_notifier/teams_notifier_test.rb
  < test/exception_notifier_test.rb
  < test/exception_notifier/webhook_notifier_test.rb
  < test/support/exception_notifier_helper.rb
  < test/support/views/exception_notifier/_new_bkg_section.html.erb
  < test/support/views/exception_notifier/_new_bkg_section.text.erb
  < test/support/views/exception_notifier/_new_section.html.erb
  < test/support/views/exception_notifier/_new_section.text.erb
  < test/test_helper.rb
  ```

</details>