### PR TITLE
Support Microsoft Teams Workflows (Incoming Webhook – New) for Teams notifier (deprecating legacy Office 365 connector)

### DIFF
--- a/lib/exception_notifier/teams_notifier.rb
+++ b/lib/exception_notifier/teams_notifier.rb
@@ -61,9 +61,6 @@ module ExceptionNotifier
 
     private
 
-    # =========================
-    # Adaptive Card Root
-    # =========================
     def adaptive_card_payload
       {
         "type" => "AdaptiveCard",
@@ -74,9 +71,6 @@ module ExceptionNotifier
       }
     end
 
-    # =========================
-    # Card Body
-    # =========================
     def card_body
       body = []
 
@@ -127,9 +121,6 @@ module ExceptionNotifier
       }
     end
 
-    # =========================
-    # Facts
-    # =========================
     def request_fact
       {
         "title" => "Request",
@@ -151,9 +142,6 @@ module ExceptionNotifier
       }
     end
 
-    # =========================
-    # Actions
-    # =========================
     def card_actions
       actions = []
       actions << gitlab_view_link if @gitlab_url
@@ -196,9 +184,6 @@ module ExceptionNotifier
       }
     end
 
-    # =========================
-    # Helpers
-    # =========================
      def activity_title
       errors_count = @options[:accumulated_errors_count].to_i
 

--- a/lib/exception_notifier/teams_notifier.rb
+++ b/lib/exception_notifier/teams_notifier.rb
@@ -9,11 +9,8 @@ module ExceptionNotifier
     include ExceptionNotifier::BacktraceCleaner
 
     class MissingController
-      def method_missing(*args, &block)
-      end
-
-      def respond_to_missing?(*args)
-      end
+      def method_missing(*); end
+      def respond_to_missing?(*); true; end
     end
 
     attr_accessor :httparty
@@ -25,7 +22,7 @@ module ExceptionNotifier
     end
 
     def call(exception, options = {})
-      @options = options.merge(@default_options)
+      @options   = options.merge(@default_options)
       @exception = exception
       @backtrace = exception.backtrace ? clean_backtrace(exception) : nil
 
@@ -33,7 +30,7 @@ module ExceptionNotifier
 
       @application_name = @options.delete(:app_name) || rails_app_name
       @gitlab_url = @options.delete(:git_url)
-      @jira_url = @options.delete(:jira_url)
+      @jira_url   = @options.delete(:jira_url)
 
       @webhook_url = @options.delete(:webhook_url)
       raise ArgumentError, "You must provide 'webhook_url' parameter." unless @webhook_url
@@ -53,141 +50,169 @@ module ExceptionNotifier
 
       end
 
-      payload = message_text
+      payload = adaptive_card_payload
 
       @options[:body] = payload.to_json
       @options[:headers] ||= {}
       @options[:headers]["Content-Type"] = "application/json"
-      @options[:debug_output] = $stdout
 
       @httparty.post(@webhook_url, @options)
     end
 
     private
 
-    def message_text
-      text = {
-        "@type" => "MessageCard",
-        "@context" => "http://schema.org/extensions",
-        "summary" => "#{@application_name} Exception Alert",
-        "title" => "⚠️ Exception Occurred in #{env_name} ⚠️",
-        "sections" => [
-          {
-            "activityTitle" => activity_title,
-            "activitySubtitle" => @exception.message.to_s
-          }
-        ],
-        "potentialAction" => []
-      }
-
-      text["sections"].push details
-      text["potentialAction"].push gitlab_view_link unless @gitlab_url.nil?
-      text["potentialAction"].push gitlab_issue_link unless @gitlab_url.nil?
-      text["potentialAction"].push jira_issue_link unless @jira_url.nil?
-
-      text
-    end
-
-    def details
-      details = {
-        "title" => "Details",
-        "facts" => []
-      }
-
-      details["facts"].push message_request unless @request_items.nil?
-      details["facts"].push message_backtrace unless @backtrace.nil?
-      details["facts"].push additional_exception_data unless @additional_exception_data.nil?
-      details
-    end
-
-    def activity_title
-      errors_count = @options[:accumulated_errors_count].to_i
-
-      "#{(errors_count > 1) ? errors_count : "A"} *#{@exception.class}* occurred" +
-        (@controller ? " in *#{controller_and_method}*." : ".")
-    end
-
-    def message_request
+    # =========================
+    # Adaptive Card Root
+    # =========================
+    def adaptive_card_payload
       {
-        "name" => "Request",
-        "value" => "#{hash_presentation(@request_items)}\n  "
+        "type" => "AdaptiveCard",
+        "$schema" => "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version" => "1.4",
+        "body" => card_body,
+        "actions" => card_actions
       }
     end
 
-    def message_backtrace(size = 3)
-      text = []
-      size = (@backtrace.size < size) ? @backtrace.size : size
-      text << "```"
-      size.times { |i| text << "* " + @backtrace[i] }
-      text << "```"
+    # =========================
+    # Card Body
+    # =========================
+    def card_body
+      body = []
 
+      body << header_block
+      body << activity_block
+      body << message_block
+      body << facts_block if facts_block
+
+      body.compact
+    end
+
+    def header_block
       {
-        "name" => "Backtrace",
-        "value" => text.join("  \n").to_s
+        "type" => "TextBlock",
+        "text" => "⚠️ Exception Occurred in #{env_name} ⚠️",
+        "weight" => "bolder",
+        "size" => "large"
       }
     end
 
-    def additional_exception_data
+    def activity_block
       {
-        "name" => "Data",
-        "value" => "`#{@additional_exception_data}`\n  "
+        "type" => "TextBlock",
+        "text" => activity_title
       }
+    end
+
+    def message_block
+      {
+        "type" => "TextBlock",
+        "text" => @exception.message.to_s,
+        "wrap" => true,
+        "isSubtle" => true
+      }
+    end
+
+    def facts_block
+      facts = []
+      facts << request_fact if @request_items
+      facts << backtrace_fact if @backtrace
+      facts << data_fact if @additional_exception_data
+
+      return nil if facts.empty?
+
+      {
+        "type" => "FactSet",
+        "facts" => facts
+      }
+    end
+
+    # =========================
+    # Facts
+    # =========================
+    def request_fact
+      {
+        "title" => "Request",
+        "value" => hash_presentation(@request_items)
+      }
+    end
+
+    def backtrace_fact(limit = 3)
+      {
+        "title" => "Backtrace",
+        "value" => @backtrace.first(limit).join("\n")
+      }
+    end
+
+    def data_fact
+      {
+        "title" => "Data",
+        "value" => @additional_exception_data.to_s
+      }
+    end
+
+    # =========================
+    # Actions
+    # =========================
+    def card_actions
+      actions = []
+      actions << gitlab_view_link if @gitlab_url
+      actions << gitlab_issue_link if @gitlab_url
+      actions << jira_issue_link if @jira_url
+      actions
     end
 
     def gitlab_view_link
       {
-        "@type" => "ViewAction",
-        "name" => "\u{1F98A} View in GitLab",
-        "target" => [
-          "#{@gitlab_url}/#{@application_name}"
-        ]
+        "type" => "Action.OpenUrl",
+        "title" => "🦊 View in GitLab",
+        "url" => "#{@gitlab_url}/#{@application_name}"
       }
     end
 
     def gitlab_issue_link
       link = [@gitlab_url, @application_name, "issues", "new"].join("/")
       params = {
-        "issue[title]" => ["[BUG] Error 500 :",
+        "issue[title]" => [
+          "[BUG]",
           controller_and_method,
           "(#{@exception.class})",
-          @exception.message].compact.join(" ")
+          @exception.message
+        ].compact.join(" ")
       }.to_query
 
       {
-        "@type" => "ViewAction",
-        "name" => "\u{1F98A} Create Issue in GitLab",
-        "target" => [
-          "#{link}/?#{params}"
-        ]
+        "type" => "Action.OpenUrl",
+        "title" => "🦊 Create Issue in GitLab",
+        "url" => "#{link}?#{params}"
       }
     end
 
     def jira_issue_link
       {
-        "@type" => "ViewAction",
-        "name" => "🐞 Create Issue in Jira",
-        "target" => [
-          "#{@jira_url}/secure/CreateIssue!default.jspa"
-        ]
+        "type" => "Action.OpenUrl",
+        "title" => "Create Jira Issue",
+        "url" => "#{@jira_url}/secure/CreateIssue!default.jspa"
       }
     end
 
+    # =========================
+    # Helpers
+    # =========================
+     def activity_title
+      errors_count = @options[:accumulated_errors_count].to_i
+
+      "#{(errors_count > 1) ? errors_count : "A"} *#{@exception.class}* occurred" +
+        (@controller ? " in *#{controller_and_method}*." : ".")
+    end
+
     def controller_and_method
-      if @controller
-        "#{@controller.controller_name}##{@controller.action_name}"
-      else
-        ""
-      end
+      return "" unless @controller
+      "#{@controller.controller_name}##{@controller.action_name}"
     end
 
     def hash_presentation(hash)
-      text = []
-
-      hash.each do |key, value|
-        text << "* **#{key}** : `#{value}`"
-      end
-
-      text.join("  \n")
+      hash.map { |k, v| "#{k}: #{v}" }.join("\n")
     end
 
     def rails_app_name

--- a/test/exception_notifier/teams_notifier_test.rb
+++ b/test/exception_notifier/teams_notifier_test.rb
@@ -13,16 +13,16 @@ class TeamsNotifierTest < ActiveSupport::TestCase
 
     options = teams_notifier.call ArgumentError.new("foo"), options
 
-    body = ActiveSupport::JSON.decode options[:body]
-    assert body.key? "title"
-    assert body.key? "sections"
+    payload = ActiveSupport::JSON.decode options[:body]
+    assert payload.key? "type"
+    assert payload.key? "body"
 
-    sections = body["sections"]
-    header = sections[0]
+    body = payload["body"]
+    header = body[0]
+    title = body[1]
 
-    assert_equal 2, sections.size
-    assert_equal "A *ArgumentError* occurred.", header["activityTitle"]
-    assert_equal "foo", header["activitySubtitle"]
+    assert_equal 3, body.size
+    assert_equal "A *ArgumentError* occurred.", title["text"]
   end
 
   test "should send notification with create gitlab issue link if specified" do
@@ -35,12 +35,12 @@ class TeamsNotifierTest < ActiveSupport::TestCase
 
     options = teams_notifier.call ArgumentError.new("foo"), options
 
-    body = ActiveSupport::JSON.decode options[:body]
+    payload = ActiveSupport::JSON.decode options[:body]
 
-    potential_action = body["potentialAction"]
+    potential_action = payload["actions"]
     assert_equal 2, potential_action.size
-    assert_equal "🦊 View in GitLab", potential_action[0]["name"]
-    assert_equal "🦊 Create Issue in GitLab", potential_action[1]["name"]
+    assert_equal "🦊 View in GitLab", potential_action[0]["title"]
+    assert_equal "🦊 Create Issue in GitLab", potential_action[1]["title"]
   end
 
   test "should add other HTTParty options to params" do
@@ -69,9 +69,9 @@ class TeamsNotifierTest < ActiveSupport::TestCase
     teams_notifier.instance_variable_set(:@exception, exception)
     teams_notifier.instance_variable_set(:@options, {})
 
-    message_text = teams_notifier.send(:message_text)
-    header = message_text["sections"][0]
-    assert_equal "A *ArgumentError* occurred.", header["activityTitle"]
+    message_text = teams_notifier.send(:adaptive_card_payload)
+    header = message_text["body"][1]
+    assert_equal "A *ArgumentError* occurred.", header["text"]
   end
 
   test "should use direct errors count if :accumulated_errors_count option is 5" do
@@ -79,9 +79,9 @@ class TeamsNotifierTest < ActiveSupport::TestCase
     exception = ArgumentError.new("foo")
     teams_notifier.instance_variable_set(:@exception, exception)
     teams_notifier.instance_variable_set(:@options, accumulated_errors_count: 5)
-    message_text = teams_notifier.send(:message_text)
-    header = message_text["sections"][0]
-    assert_equal "5 *ArgumentError* occurred.", header["activityTitle"]
+    message_text = teams_notifier.send(:adaptive_card_payload)
+    header = message_text["body"][1]
+    assert_equal "5 *ArgumentError* occurred.", header["text"]
   end
 end
 


### PR DESCRIPTION
Microsoft Teams is deprecating the legacy Office 365 Connector–based Incoming Webhooks on 31 December.
The current MS Teams notifier in exception_notification relies on this deprecated webhook format.

This PR updates the Teams notifier to support the new Microsoft Teams Workflows Incoming Webhook, which uses a different payload structure, ensuring notifications continue to work after the deprecation.

**What Changed**

- Updated Teams notifier payload to match Workflow Incoming Webhook requirements
- No changes to the public notifier API
- Existing behavior preserved where possible
- Added/updated tests for the new payload format

**Reproduction / Verification**

_Before_

1. Configure the MS Teams notifier using the existing (legacy) webhook
2. Trigger an exception
3. Notifications rely on deprecated connector format

_After_

1. Create a Microsoft Teams Workflow with an Incoming Webhook
2. Configure the notifier with the new webhook URL
3. Trigger an exception
4. Notification is successfully delivered to the Teams channel

**Tests**

- Added automated tests for Workflow webhook payload
- All existing tests pass
- Manually verified using a real MS Teams Workflow webhook